### PR TITLE
fix: remove invalid text-justify, add cursor:pointer to images

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@
 
 - ✅ **Remove dead HTML clutter + add meta tags + defer scripts + aria-label** (`revamp/qw-1-5-6-7-html-cleanup`) — removed empty nav/ul/footer/div ghosts; added viewport & description meta; deferred Chart.js and bus-mall.js; added aria-label to canvas; moved script to end of body.
 - ✅ **Remove dead JS variables** (`revamp/qw-2-dead-js-vars`) — removed unused `voteCount`, commented-out `resultButton`, and orphaned `Product.allProductsArr` comment.
+- ✅ **CSS fixes: remove invalid `text-justify`, add `cursor: pointer`** (`revamp/qw-3-4-css-fixes`) — dropped the invalid `text-justify: center` declaration; added `cursor: pointer` to image list items so users know they're clickable.

--- a/styles/style.css
+++ b/styles/style.css
@@ -9,10 +9,8 @@ body {
 
 h1 {
   color: #e9c46a;
-  text-justify: center;
   text-align: center;
   font-size: 45px;
-  /* margin-top: 30px; */
 }
 
 header {
@@ -82,6 +80,7 @@ section ul li {
   height: 100px;
   width: 100px;
   display: flex;
+  cursor: pointer;
 }
 
 h2 {


### PR DESCRIPTION
## Summary
- Removed `text-justify: center` from `h1` — not a valid value, browser ignored it silently
- Added `cursor: pointer` to `section ul li` so users get a visual click affordance on product images

## Test plan
- [ ] h1 heading still centered (text-align:center remains)
- [ ] Hovering over product images shows pointer cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)