### PR TITLE
fix: guard handleClick against non-image clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@
 - ✅ **Remove dead HTML clutter + add meta tags + defer scripts + aria-label** (`revamp/qw-1-5-6-7-html-cleanup`) — removed empty nav/ul/footer/div ghosts; added viewport & description meta; deferred Chart.js and bus-mall.js; added aria-label to canvas; moved script to end of body.
 - ✅ **Remove dead JS variables** (`revamp/qw-2-dead-js-vars`) — removed unused `voteCount`, commented-out `resultButton`, and orphaned `Product.allProductsArr` comment.
 - ✅ **CSS fixes: remove invalid `text-justify`, add `cursor: pointer`** (`revamp/qw-3-4-css-fixes`) — dropped the invalid `text-justify: center` declaration; added `cursor: pointer` to image list items so users know they're clickable.
+
+### Moderate
+
+- ✅ **Fix `handleClick` non-image click guard** (`revamp/mod-8-click-guard`) — clicking the orange `<ul>` padding (not an image) previously decremented the vote counter without registering a vote; guard now returns early if `event.target` is not an `<img>`.

--- a/js/bus-mall.js
+++ b/js/bus-mall.js
@@ -179,10 +179,12 @@ function renderChart() {
 //******************************************** */
 
 function handleClick(event) {
+  if (event.target.tagName !== 'IMG') return;
+
   maxClicksAllowed--;
-  
+
   let imgClicked = event.target.alt;
-  
+
   for (let i = 0; i < allProductsArr.length; i++) {
     if (imgClicked === allProductsArr[i].name) {
       allProductsArr[i].votes++;


### PR DESCRIPTION
## Summary
Clicking the salmon-colored `<ul>` padding area (outside an image but inside the products container) previously decremented `maxClicksAllowed` without registering a vote, so results could appear after fewer than 25 real votes. Added an early `return` when `event.target.tagName !== 'IMG'`.

## Test plan
- [ ] Clicking directly on an image counts the vote and re-renders normally
- [ ] Clicking the orange padding between images does nothing
- [ ] Results chart still appears after exactly 25 image clicks

🤖 Generated with [Claude Code](https://claude.com/claude-code)