### PR TITLE
fix: persist votes to localStorage after every click

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@
 ### Moderate
 
 - ✅ **Fix `handleClick` non-image click guard** (`revamp/mod-8-click-guard`) — clicking the orange `<ul>` padding (not an image) previously decremented the vote counter without registering a vote; guard now returns early if `event.target` is not an `<img>`.
+- ✅ **Fix localStorage vote persistence** (`revamp/mod-9-localstorage-fix`) — votes were only saved to localStorage at page load; now saved after every click via a `saveProducts()` helper, so vote data survives a refresh.

--- a/js/bus-mall.js
+++ b/js/bus-mall.js
@@ -178,6 +178,10 @@ function renderChart() {
 //            EVENT HANDLERS
 //******************************************** */
 
+function saveProducts() {
+  localStorage.setItem('products', JSON.stringify(allProductsArr));
+}
+
 function handleClick(event) {
   if (event.target.tagName !== 'IMG') return;
 
@@ -191,6 +195,7 @@ function handleClick(event) {
       allProductsArr[i].views++;
     }
   }
+  saveProducts();
   renderProducts();
 
   if (maxClicksAllowed === 0) {
@@ -210,13 +215,5 @@ function handleShowResults() {
 
 productContainer.addEventListener('click', handleClick);
 
-/* **********************************************
-                  LOCAL STORAGE
-********************************************** */
-
-// STEP 1: STRINGIFY DATA
-let stringifiedProducts = JSON.stringify(allProductsArr);
-
-// STEP 2: ADD TO LOCAL STORAGE
-localStorage.setItem('products', stringifiedProducts);
+saveProducts();
 


### PR DESCRIPTION
## Summary
- `localStorage.setItem` was called once at page load, before any votes — votes cast during the session were lost on refresh
- Extracted a `saveProducts()` helper and call it inside `handleClick` after updating votes
- The initial startup save (which seeds localStorage if empty) now also uses `saveProducts()`

## Test plan
- [ ] Cast several votes, refresh the page — chart shows those votes persisted
- [ ] Clear localStorage and reload — products initialize fresh with 0 votes

🤖 Generated with [Claude Code](https://claude.com/claude-code)