### PR TITLE
refactor: CSS custom properties for color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@
 
 - ✅ **Fix `handleClick` non-image click guard** (`revamp/mod-8-click-guard`) — clicking the orange `<ul>` padding (not an image) previously decremented the vote counter without registering a vote; guard now returns early if `event.target` is not an `<img>`.
 - ✅ **Fix localStorage vote persistence** (`revamp/mod-9-localstorage-fix`) — votes were only saved to localStorage at page load; now saved after every click via a `saveProducts()` helper, so vote data survives a refresh.
+- ✅ **CSS custom properties for color palette** (`revamp/mod-10-css-custom-props`) — extracted 5 colors into `:root` variables; removed dead commented-out blocks and orphaned nav/footer rules; fixed aggressive global `p { height: 300px }` that conflicted with footer text.

--- a/styles/style.css
+++ b/styles/style.css
@@ -1,50 +1,33 @@
-
+:root {
+  --color-dark: #264653;
+  --color-teal: #2a9d8f;
+  --color-coral: #e76f51;
+  --color-yellow: #e9c46a;
+  --color-orange: #f4a261;
+}
 
 body {
   font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;
-  background-color: #2a9d8f;
+  background-color: var(--color-teal);
   width: 90%;
   margin: auto;
 }
 
 h1 {
-  color: #e9c46a;
+  color: var(--color-yellow);
   text-align: center;
   font-size: 45px;
 }
 
 header {
-  background-color: #264653;
+  background-color: var(--color-dark);
   height: 100px;
   margin-bottom: 30px;
 }
 
-nav {
-  width: 90%;
-  margin: auto;
-}
-
-/* 
-nav img {
-  float: left;
-  margin-top: 15px;
-  margin-right: 10px;
-} */
-
-nav ul {
-  display: flex;
-  justify-content: space-around;
-  width: 90%;
-  margin: auto;
-}
-
-nav ul li {
-  margin-top: 40px;
-}
-
 a {
   text-decoration: none;
-  color: #e9c46a;
+  color: var(--color-yellow);
 }
 
 main {
@@ -52,28 +35,19 @@ main {
   margin: auto;
 }
 
-/* #products {
-  background-color: #e76f51;
-  width: 90%;
-  margin: auto;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-} */
-
 section {
   width: 100%;
   margin: auto;
 }
+
 /* PRODUCT IMAGES */
 
 section ul {
-	display: flex;
-	/* margin: auto; */
+  display: flex;
   width: 100%;
   justify-content: space-between;
   align-items: center;
-  background-color: #e76f51;
+  background-color: var(--color-coral);
 }
 
 section ul li {
@@ -87,17 +61,11 @@ h2 {
   font-size: 30px;
   margin-bottom: 10px;
   margin-top: 10px;
-  color: #264653;
-  background-color: #e76f51;
+  color: var(--color-dark);
+  background-color: var(--color-coral);
   width: 100%;
 }
 
-p {
-  height: 300px;
-  overflow: auto;
-}
-
-/* button */
 button {
   margin-top: 15px;
   background-color: black;
@@ -106,31 +74,16 @@ button {
 }
 
 button:hover {
-  background-color: #f4a261;
+  background-color: var(--color-orange);
 }
 
 /* FOOTER */
 
 footer {
-	height: 150px;
-	background-color: #264653;
-  color:#e9c46a;
-}
-
-footer ul {
-  justify-content: space-evenly;
-}
-
-footer ul li {
-  float: left;
-  height: 5px;
-  width: 100px;
-}
-
-footer p {
   height: 150px;
-  width: 150px;
-  justify-content: space-around;
+  background-color: var(--color-dark);
+  color: var(--color-yellow);
   display: flex;
+  align-items: center;
+  justify-content: center;
 }
-


### PR DESCRIPTION
## Summary
- Added `:root` block with 5 named color variables (`--color-dark`, `--color-teal`, `--color-coral`, `--color-yellow`, `--color-orange`)
- Replaced all raw hex literals with `var()` references
- Removed dead commented-out blocks (`#products`, `nav img`)
- Removed orphaned nav/footer-child rules whose HTML was removed in a prior PR
- Fixed `p { height: 300px }` global rule that was bleeding into footer text
- Footer copyright now centers via flexbox

## Test plan
- [ ] Colors look identical to before
- [ ] Footer copyright text is centered and visible
- [ ] No layout regressions on the product image row or chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)