### PR TITLE
feat: increase product image size with object-fit

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@
 - ✅ **Fix `handleClick` non-image click guard** (`revamp/mod-8-click-guard`) — clicking the orange `<ul>` padding (not an image) previously decremented the vote counter without registering a vote; guard now returns early if `event.target` is not an `<img>`.
 - ✅ **Fix localStorage vote persistence** (`revamp/mod-9-localstorage-fix`) — votes were only saved to localStorage at page load; now saved after every click via a `saveProducts()` helper, so vote data survives a refresh.
 - ✅ **CSS custom properties for color palette** (`revamp/mod-10-css-custom-props`) — extracted 5 colors into `:root` variables; removed dead commented-out blocks and orphaned nav/footer rules; fixed aggressive global `p { height: 300px }` that conflicted with footer text.
+- ✅ **Product images properly sized** (`revamp/mod-11-image-size`) — increased image containers from 100×100 px to 220 px tall flexible columns with `object-fit: contain`; added vertical padding to the product row.

--- a/styles/style.css
+++ b/styles/style.css
@@ -45,16 +45,27 @@ section {
 section ul {
   display: flex;
   width: 100%;
-  justify-content: space-between;
+  justify-content: space-around;
   align-items: center;
   background-color: var(--color-coral);
+  padding: 20px 0;
+  gap: 16px;
 }
 
 section ul li {
-  height: 100px;
-  width: 100px;
+  flex: 1;
+  max-width: 280px;
+  height: 220px;
   display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
+}
+
+section ul li img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 h2 {


### PR DESCRIPTION
## Summary
- Product image containers were 100×100 px — too small to see product details
- Changed `section ul li` to flex children that each take equal width up to 280 px max, with 220 px height
- Added `object-fit: contain` on `img` so no image is cropped regardless of aspect ratio
- Added padding on the coral row so images breathe

## Test plan
- [ ] Three product images appear side-by-side, clearly visible and not cropped
- [ ] Clicking any image still registers a vote and re-renders the next set
- [ ] Row layout is intact — no overflow or stacking

🤖 Generated with [Claude Code](https://claude.com/claude-code)