### PR TITLE
feat: instructions banner with live vote countdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@
 - ✅ **Fix localStorage vote persistence** (`revamp/mod-9-localstorage-fix`) — votes were only saved to localStorage at page load; now saved after every click via a `saveProducts()` helper, so vote data survives a refresh.
 - ✅ **CSS custom properties for color palette** (`revamp/mod-10-css-custom-props`) — extracted 5 colors into `:root` variables; removed dead commented-out blocks and orphaned nav/footer rules; fixed aggressive global `p { height: 300px }` that conflicted with footer text.
 - ✅ **Product images properly sized** (`revamp/mod-11-image-size`) — increased image containers from 100×100 px to 220 px tall flexible columns with `object-fit: contain`; added vertical padding to the product row.
+- ✅ **Add user instructions with live vote counter** (`revamp/mod-12-instructions`) — added a yellow instruction banner below the image row showing remaining votes; banner hides and chart reveals when voting ends.

--- a/bus-mall.html
+++ b/bus-mall.html
@@ -22,8 +22,10 @@
       </ul>
     </section>
 
+    <p id="instructions">Click your favorite product to vote! <span id="votes-remaining">25</span> votes remaining.</p>
+
     <canvas id="myChart" width="400" height="400"
-      aria-label="Bar chart showing votes and views per product" role="img"></canvas>
+      aria-label="Bar chart showing votes and views per product" role="img" hidden></canvas>
   </main>
   <footer>
     <p>&copy; 2024 Bus Mall</p>

--- a/js/bus-mall.js
+++ b/js/bus-mall.js
@@ -6,8 +6,11 @@ let productContainer = document.getElementById('products');
 let image1 = document.getElementById('imgOne');
 let image2 = document.getElementById('imgTwo');
 let image3 = document.getElementById('imgThree');
+let instructions = document.getElementById('instructions');
+let votesRemaining = document.getElementById('votes-remaining');
+let chartCanvas = document.getElementById('myChart');
 
-let ctx = document.getElementById('myChart').getContext('2d');
+let ctx = chartCanvas.getContext('2d');
 // ***********Click Variables****************
 
 let clicks = 0;
@@ -186,6 +189,7 @@ function handleClick(event) {
   if (event.target.tagName !== 'IMG') return;
 
   maxClicksAllowed--;
+  votesRemaining.textContent = maxClicksAllowed;
 
   let imgClicked = event.target.alt;
 
@@ -204,9 +208,10 @@ function handleClick(event) {
 }
 
 function handleShowResults() {
-    productContainer.removeEventListener('click', handleClick);
-    renderChart();
-
+  productContainer.removeEventListener('click', handleClick);
+  instructions.hidden = true;
+  chartCanvas.hidden = false;
+  renderChart();
 }
 
 //****************************************

--- a/styles/style.css
+++ b/styles/style.css
@@ -77,6 +77,15 @@ h2 {
   width: 100%;
 }
 
+#instructions {
+  text-align: center;
+  font-size: 1.2rem;
+  color: var(--color-dark);
+  background-color: var(--color-yellow);
+  padding: 12px 20px;
+  font-weight: bold;
+}
+
 button {
   margin-top: 15px;
   background-color: black;


### PR DESCRIPTION
## Summary
- Added `<p id="instructions">` banner below the image row with a live `<span id="votes-remaining">` counter
- Styled it in yellow (`--color-yellow`) so it stands out against the teal background
- Counter decrements on each valid image click
- When votes run out: banner gets `hidden`, canvas has `hidden` removed, chart renders

## Test plan
- [ ] Page loads showing "Click your favorite product to vote! 25 votes remaining."
- [ ] Counter decrements with each click
- [ ] At 0 remaining: instruction banner disappears, chart appears
- [ ] Clicking padding (non-image) does not decrement counter (guard from item 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)