### PR TITLE
fix: generate distinct chart colors for all 18 products

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@
 - ✅ **CSS custom properties for color palette** (`revamp/mod-10-css-custom-props`) — extracted 5 colors into `:root` variables; removed dead commented-out blocks and orphaned nav/footer rules; fixed aggressive global `p { height: 300px }` that conflicted with footer text.
 - ✅ **Product images properly sized** (`revamp/mod-11-image-size`) — increased image containers from 100×100 px to 220 px tall flexible columns with `object-fit: contain`; added vertical padding to the product row.
 - ✅ **Add user instructions with live vote counter** (`revamp/mod-12-instructions`) — added a yellow instruction banner below the image row showing remaining votes; banner hides and chart reveals when voting ends.
+- ✅ **Fix Chart.js colors for all 18 products** (`revamp/mod-13-chart-colors`) — replaced 6-entry hardcoded color arrays with `makeChartColors()` that generates evenly-spaced HSL hues dynamically, giving each product a distinct color.

--- a/js/bus-mall.js
+++ b/js/bus-mall.js
@@ -114,18 +114,21 @@ renderProducts();
 // *********************************************
 //              CHART RENDERING
 // *********************************************
-// ...to replace resuts li rendering function
-function renderChart() {
 
-  let productName = [];
-  let productVotes = [];
-  let productViews = [];
-
-  for (let i = 0; i < allProductsArr.length; i++) {
-    productName.push(allProductsArr[i].name);
-    productVotes.push(allProductsArr[i].votes);
-    productViews.push(allProductsArr[i].views);
+function makeChartColors(count, alpha) {
+  let colors = [];
+  for (let i = 0; i < count; i++) {
+    let hue = Math.round((i / count) * 360);
+    colors.push(`hsla(${hue}, 70%, 55%, ${alpha})`);
   }
+  return colors;
+}
+
+function renderChart() {
+  let productName = allProductsArr.map(p => p.name);
+  let productVotes = allProductsArr.map(p => p.votes);
+  let productViews = allProductsArr.map(p => p.views);
+  let count = allProductsArr.length;
 
   new Chart(ctx, {
     type: 'bar',
@@ -134,42 +137,14 @@ function renderChart() {
       datasets: [{
         label: '# of Votes',
         data: productVotes,
-        backgroundColor: [
-          'rgba(255, 99, 132, 0.2)',
-          'rgba(54, 162, 235, 0.2)',
-          'rgba(255, 206, 86, 0.2)',
-          'rgba(75, 192, 192, 0.2)',
-          'rgba(153, 102, 255, 0.2)',
-          'rgba(255, 159, 64, 0.2)'
-        ],
-        borderColor: [
-          'rgba(255, 99, 132, 1)',
-          'rgba(54, 162, 235, 1)',
-          'rgba(255, 206, 86, 1)',
-          'rgba(75, 192, 192, 1)',
-          'rgba(153, 102, 255, 1)',
-          'rgba(255, 159, 64, 1)'
-        ],
+        backgroundColor: makeChartColors(count, 0.7),
+        borderColor: makeChartColors(count, 1),
         borderWidth: 1
       }, {
         label: '# of Views',
         data: productViews,
-        backgroundColor: [
-          'rgba(255, 99, 132, 0.2)',
-          'rgba(54, 162, 235, 0.2)',
-          'rgba(255, 206, 86, 0.2)',
-          'rgba(75, 192, 192, 0.2)',
-          'rgba(153, 102, 255, 0.2)',
-          'rgba(255, 159, 64, 0.2)'
-        ],
-        borderColor: [
-          'rgba(255, 99, 132, 1)',
-          'rgba(54, 162, 235, 1)',
-          'rgba(255, 206, 86, 1)',
-          'rgba(75, 192, 192, 1)',
-          'rgba(153, 102, 255, 1)',
-          'rgba(255, 159, 64, 1)'
-        ],
+        backgroundColor: makeChartColors(count, 0.3),
+        borderColor: makeChartColors(count, 0.8),
         borderWidth: 1
       }]
     },


### PR DESCRIPTION
## Summary
- Previous code had 6 hardcoded colors; products 7–18 had no color (transparent bars)
- Added `makeChartColors(count, alpha)` which distributes hues evenly across the HSL wheel
- Votes dataset uses alpha 0.7/1.0; Views dataset uses 0.3/0.8 so they're visually distinct
- Also replaced data-collection `for` loops with `Array.map()`

## Test plan
- [ ] After 25 votes, chart shows all 18 products with distinct, non-repeating colors
- [ ] Votes bars are more opaque than Views bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)