### PR TITLE
refactor: convert Product constructor to ES6 class

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@
 - ✅ **Add user instructions with live vote counter** (`revamp/mod-12-instructions`) — added a yellow instruction banner below the image row showing remaining votes; banner hides and chart reveals when voting ends.
 - ✅ **Fix Chart.js colors for all 18 products** (`revamp/mod-13-chart-colors`) — replaced 6-entry hardcoded color arrays with `makeChartColors()` that generates evenly-spaced HSL hues dynamically, giving each product a distinct color.
 - ✅ **Refactor `renderProducts` to use a loop** (`revamp/mod-14-render-refactor`) — replaced 3 repeated src/alt/views blocks and 3 separate image globals with an `imageEls` array and a `forEach` loop; also removed unused `clicks` variable.
+
+### Deep Refactors
+
+- ✅ **Convert `Product` constructor to ES6 `class`** (`revamp/deep-15-es6-class`) — modernized from `function Product()` prototype pattern to `class Product { constructor() {} }`; also cleaned up the instantiation section comments and inlined the `JSON.parse` call.

--- a/js/bus-mall.js
+++ b/js/bus-mall.js
@@ -16,34 +16,21 @@ let ctx = chartCanvas.getContext('2d');
 
 let maxClicksAllowed = 25;
 let uniqueImageCount = 6;
-// *******************************************
-//             CONSTRUCTOR
-//********************************************
-
-function Product(name, fileExtension = 'jpg') {
-  this.name = name;
-  this.views = 0;
-  this.votes = 0;
-  this.photo = `img/${name}.${fileExtension}`
-
-  allProductsArr.push(this);
+class Product {
+  constructor(name, fileExtension = 'jpg') {
+    this.name = name;
+    this.views = 0;
+    this.votes = 0;
+    this.photo = `img/${name}.${fileExtension}`;
+    allProductsArr.push(this);
+  }
 }
-
-// *********************************************
-//     INSTANTIATION & LOCAL STORAGE PT 2
-// *********************************************
 
 let retrievedProducts = localStorage.getItem('products');
 
-// LOCAL STORAGE PT 4
-let parsedProducts = JSON.parse(retrievedProducts);
-
-// EASY WAY
 if (retrievedProducts) {
-  allProductsArr = parsedProducts;
+  allProductsArr = JSON.parse(retrievedProducts);
 } else {
-
-
   new Product('bag');
   new Product('banana');
   new Product('boots');


### PR DESCRIPTION
## Summary
- Converted `function Product(name, fileExtension){}` to `class Product { constructor(name, fileExtension){} }`
- Behavior is identical — ES6 class is syntactic sugar over the same prototype chain
- Inlined the `JSON.parse` call (removed intermediate `parsedProducts` variable)
- Removed verbose step-numbered comments in the instantiation block

## Test plan
- [ ] App loads and renders product images as before
- [ ] Voting and chart rendering work identically
- [ ] localStorage round-trip still works (products persist after refresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)