### PR TITLE
fix: hide products on results, make chart fill viewport

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 ### Visual Overhaul
 
 - ✅ **Viewport-filling product cards** (`revamp/voting-ui-fix`) — replaced fixed-size image containers with a flex-fill chain (`body → main → #products → ul → li → .product-btn → img`) so cards grow to use all available vertical space; fixed `[hidden]` specificity bug where `#vote-ui { display: flex }` overrode `[hidden]`; added section prompt, product-name labels, progress-bar counter, and chart polish.
+- ✅ **Fix results layout** (`revamp/fix-results-layout`) — `#products` was not hidden when results rendered so cards lingered above the chart; added `productContainer.hidden = true` to `handleShowResults()`; converted `#chart-container` to a flex column with an absolutely positioned `.chart-wrap` so the Chart.js canvas fills the full available viewport height.
 
 ---
 

--- a/bus-mall.html
+++ b/bus-mall.html
@@ -62,8 +62,10 @@
         <h2>Results</h2>
         <p class="chart-subtitle">Votes &amp; views across all products</p>
       </div>
-      <canvas id="myChart"
-        aria-label="Bar chart showing votes and views per product" role="img"></canvas>
+      <div class="chart-wrap">
+        <canvas id="myChart"
+          aria-label="Bar chart showing votes and views per product" role="img"></canvas>
+      </div>
     </div>
   </main>
 

--- a/js/bus-mall.js
+++ b/js/bus-mall.js
@@ -189,6 +189,7 @@ function handleClick(event) {
 
 function handleShowResults() {
   productContainer.removeEventListener('click', handleClick);
+  productContainer.hidden = true;
   voteUI.hidden = true;
   chartContainer.hidden = false;
   renderChart();

--- a/styles/style.css
+++ b/styles/style.css
@@ -246,7 +246,10 @@ main {
 /* ── CHART ─────────────────────────────────────── */
 
 #chart-container {
-  flex-shrink: 0;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
   background: var(--clr-card);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-md);
@@ -254,6 +257,7 @@ main {
 }
 
 .chart-header {
+  flex-shrink: 0;
   text-align: center;
   margin-bottom: 20px;
 }
@@ -273,9 +277,18 @@ main {
   font-weight: 400;
 }
 
+.chart-wrap {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}
+
 #myChart {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100% !important;
-  height: 380px !important;
+  height: 100% !important;
 }
 
 /* ── FOOTER ────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- `handleShowResults()` was never setting `productContainer.hidden = true`, so the voting cards and section prompt stayed visible above the chart after all 25 votes — fixed with one line in JS
- `#chart-container` had `flex-shrink: 0` and the canvas had `height: 380px !important`, leaving large empty whitespace below the chart — fixed by making the container a flex column, adding a `.chart-wrap` wrapper with `position: relative`, and positioning the canvas absolutely inside it so Chart.js reads the correct dimensions

## Test plan
- [ ] Cast all 25 votes — product cards should disappear completely and chart should fill the page
- [ ] Chart x-axis labels and bars should all be visible (no clipping)
- [ ] Reload page mid-session — voting state should resume correctly from localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)