### PR TITLE
refactor: reorganise layout — control bar + cards two-zone design

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 
 - ✅ **Viewport-filling product cards** (`revamp/voting-ui-fix`) — replaced fixed-size image containers with a flex-fill chain (`body → main → #products → ul → li → .product-btn → img`) so cards grow to use all available vertical space; fixed `[hidden]` specificity bug where `#vote-ui { display: flex }` overrode `[hidden]`; added section prompt, product-name labels, progress-bar counter, and chart polish.
 - ✅ **Fix results layout** (`revamp/fix-results-layout`) — `#products` was not hidden when results rendered so cards lingered above the chart; added `productContainer.hidden = true` to `handleShowResults()`; converted `#chart-container` to a flex column with an absolutely positioned `.chart-wrap` so the Chart.js canvas fills the full available viewport height.
+- ✅ **Layout reorganisation** (`revamp/layout-reorganise`) — moved `#vote-ui` above `#products` and merged the section prompt into it as a horizontal control bar (prompt left, counter right, progress bar full-width below); removed the orphaned centered counter at the bottom; updated mobile responsive rules so the row stacks cleanly on narrow screens.
 
 ---
 

--- a/bus-mall.html
+++ b/bus-mall.html
@@ -21,8 +21,22 @@
   </header>
 
   <main>
+    <div id="vote-ui">
+      <div class="vote-ui-row">
+        <p class="section-prompt">Which would you actually buy on your commute?</p>
+        <div id="vote-counter">
+          <span id="votes-remaining">25</span>
+          <span class="vote-label">votes left</span>
+        </div>
+      </div>
+      <div id="progress-track"
+           role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="25"
+           aria-label="Voting progress">
+        <div id="progress-fill"></div>
+      </div>
+    </div>
+
     <section id="products">
-      <p class="section-prompt">Which would you actually buy on your commute?</p>
       <ul>
         <li>
           <button class="product-btn">
@@ -44,18 +58,6 @@
         </li>
       </ul>
     </section>
-
-    <div id="vote-ui">
-      <div id="vote-counter">
-        <span id="votes-remaining">25</span>
-        <span class="vote-label">votes left</span>
-      </div>
-      <div id="progress-track"
-           role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="25"
-           aria-label="Voting progress">
-        <div id="progress-fill"></div>
-      </div>
-    </div>
 
     <div id="chart-container" hidden>
       <div class="chart-header">

--- a/styles/style.css
+++ b/styles/style.css
@@ -95,18 +95,76 @@ main {
   gap: 16px;
 }
 
-/* ── PRODUCT CARDS ─────────────────────────────── */
+/* ── VOTE UI (control bar) ─────────────────────── */
+
+#vote-ui {
+  flex-shrink: 0;
+  background: var(--clr-card);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: 16px 28px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.vote-ui-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
 
 .section-prompt {
-  font-size: 0.78rem;
+  margin: 0;
+  font-size: 0.92rem;
   font-weight: 600;
-  color: var(--clr-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  text-align: center;
-  margin: 0 0 12px;
-  flex-shrink: 0;
+  color: var(--clr-text);
 }
+
+#vote-counter {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+#votes-remaining {
+  font-size: 1.9rem;
+  font-weight: 800;
+  color: var(--clr-coral);
+  letter-spacing: -0.04em;
+  line-height: 1;
+  transition: color 300ms ease;
+}
+
+#votes-remaining.low   { color: var(--clr-orange); }
+#votes-remaining.final { color: var(--clr-teal); }
+
+.vote-label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--clr-muted);
+}
+
+#progress-track {
+  width: 100%;
+  height: 6px;
+  background: rgba(42, 157, 143, 0.15);
+  border-radius: 100px;
+  overflow: hidden;
+}
+
+#progress-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, var(--clr-teal) 0%, var(--clr-coral) 100%);
+  border-radius: 100px;
+  transition: width 300ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ── PRODUCT CARDS ─────────────────────────────── */
 
 #products {
   flex: 1;
@@ -189,60 +247,6 @@ main {
   line-height: 1.3;
 }
 
-/* ── VOTE UI ───────────────────────────────────── */
-
-#vote-ui {
-  flex-shrink: 0;
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
-  padding: 4px 0 8px;
-}
-
-#vote-counter {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-  line-height: 1;
-}
-
-#votes-remaining {
-  font-size: 3.2rem;
-  font-weight: 800;
-  color: var(--clr-coral);
-  letter-spacing: -0.04em;
-  line-height: 1;
-  transition: color 300ms ease;
-}
-
-#votes-remaining.low   { color: var(--clr-orange); }
-#votes-remaining.final { color: var(--clr-teal); }
-
-.vote-label {
-  font-size: 0.95rem;
-  font-weight: 500;
-  color: var(--clr-muted);
-}
-
-#progress-track {
-  width: 100%;
-  max-width: 460px;
-  height: 8px;
-  background: rgba(42, 157, 143, 0.18);
-  border-radius: 100px;
-  overflow: hidden;
-}
-
-#progress-fill {
-  height: 100%;
-  width: 0%;
-  background: linear-gradient(90deg, var(--clr-teal) 0%, var(--clr-coral) 100%);
-  border-radius: 100px;
-  transition: width 300ms cubic-bezier(0.4, 0, 0.2, 1);
-}
-
 /* ── CHART ─────────────────────────────────────── */
 
 #chart-container {
@@ -314,12 +318,18 @@ a {
 /* ── RESPONSIVE ────────────────────────────────── */
 
 @media (max-width: 640px) {
+  main { margin: 16px auto 24px; gap: 12px; }
+
+  #vote-ui { padding: 14px 20px 12px; }
+
+  .vote-ui-row { flex-direction: column; align-items: flex-start; gap: 6px; }
+
+  #votes-remaining { font-size: 1.6rem; }
+
   #products ul {
     grid-template-columns: 1fr;
-    max-width: 320px;
+    grid-template-rows: none;
+    max-width: 340px;
     margin: 0 auto;
   }
-
-  #vote-ui { padding: 20px; }
-  #votes-remaining { font-size: 3rem; }
 }


### PR DESCRIPTION
## Summary
- Moved `#vote-ui` above `#products` so the instruction and counter appear before the cards
- Merged the orphaned `.section-prompt` paragraph into `#vote-ui` as a horizontal row: prompt text left-justified, vote counter right-justified, progress bar spanning full width below
- Removed the old isolated centered counter that floated at the bottom with no visual grouping
- Updated mobile responsive rules: row stacks to column at ≤640px, reduced counter font-size to 1.6rem

## Test plan
- [ ] Control bar shows prompt on left and "25 votes left" on right at desktop
- [ ] Progress bar fills left-to-right as votes are cast
- [ ] Counter colour transitions: coral → orange (≤12 left) → teal (≤3 left)
- [ ] Mobile: row stacks to two lines, cards are single-column
- [ ] After 25 votes: control bar hides, chart fills viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)